### PR TITLE
feat: add middleware for verifying Supabase JWT tokens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the WiseTogether server directory are documented here.
+
+---
+
+## [Unreleased]
+
+### Added
+- New API endpoint: `PATCH /transactions/:id` for editing transactions [#1](https://github.com/WiseTogether/wisetogether-server/issues/1)
+- Middleware for Supabase token verification [#2](https://github.com/WiseTogether/wisetogether-server/issues/2)
+
+---
+

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -25,13 +25,15 @@ Backend routes rely solely on client-side auth. No server-side validation of Sup
    - Add `getSupabaseClientWithAuth` function for authenticated operations
    - Centralize Supabase client configuration
 
-4. Updated `sharedAccountModel.js` to:
-   - Accept authenticated Supabase client as parameter
-   - Maintain clean data mapping
+4. Updated all models to accept authenticated Supabase client:
+   - `profileModel.js`: Updated createProfile and findByUserId
+   - `expenseModel.js`: Updated filterById and addExpense
+   - `sharedAccountModel.js`: Updated findByUserId
 
-5. Updated `sharedAccountController.js` to:
-   - Pass authenticated Supabase client to model
-   - Maintain consistent error handling
+5. Updated all controllers to pass authenticated Supabase client:
+   - `profileController.js`: Updated createUserProfile and findProfileByUserId
+   - `expenseController.js`: Updated fetchAllExpensesById, addNewPersonalExpense, and addNewSharedExpense
+   - `sharedAccountController.js`: Updated findSharedAccountByUserId
 
 ### Testing
 To test the implementation:

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -11,16 +11,27 @@ This document outlines the reasoning and technical approach behind selected chan
 Backend routes rely solely on client-side auth. No server-side validation of Supabase access token.
 
 ### Implementation
-1. Created `authMiddleware.js` with `verifyToken` middleware function that:
-   - Extracts Bearer token from Authorization header
-   - Validates token using Supabase's `auth.getUser()`
-   - Attaches verified user to request object
-   - Returns appropriate error responses for invalid/missing tokens
+1. Created `authMiddleware.js` with:
+   - `verifyToken` middleware to validate JWT tokens
+   - Uses `getSupabaseClientWithAuth` for authenticated requests
+   - Proper error handling for missing/invalid tokens
 
 2. Updated `server.js` to:
    - Import and apply middleware to all protected routes
    - Add 'Authorization' to allowed CORS headers
    - Apply middleware before route handlers
+
+3. Updated `supabaseClient.js` to:
+   - Add `getSupabaseClientWithAuth` function for authenticated operations
+   - Centralize Supabase client configuration
+
+4. Updated `sharedAccountModel.js` to:
+   - Accept authenticated Supabase client as parameter
+   - Maintain clean data mapping
+
+5. Updated `sharedAccountController.js` to:
+   - Pass authenticated Supabase client to model
+   - Maintain consistent error handling
 
 ### Testing
 To test the implementation:

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -1,0 +1,35 @@
+# Implementation Notes
+
+This document outlines the reasoning and technical approach behind selected changes during the project.
+
+---
+
+## Feat: Enforce Supabase Token Verification
+**Issue:** [#2](https://github.com/WiseTogether/wisetogether-server/issues/2)
+
+### Problem
+Backend routes rely solely on client-side auth. No server-side validation of Supabase access token.
+
+### Implementation
+1. Created `authMiddleware.js` with `verifyToken` middleware function that:
+   - Extracts Bearer token from Authorization header
+   - Validates token using Supabase's `auth.getUser()`
+   - Attaches verified user to request object
+   - Returns appropriate error responses for invalid/missing tokens
+
+2. Updated `server.js` to:
+   - Import and apply middleware to all protected routes
+   - Add 'Authorization' to allowed CORS headers
+   - Apply middleware before route handlers
+
+### Testing
+To test the implementation:
+1. Include valid Supabase JWT token in Authorization header:
+   ```
+   Authorization: Bearer <your-supabase-jwt-token>
+   ```
+2. Invalid/missing tokens will return 401 errors
+3. Valid tokens will allow access to protected routes
+
+---
+

--- a/src/controllers/expenseController.js
+++ b/src/controllers/expenseController.js
@@ -9,21 +9,21 @@ const fetchAllExpensesById = async (req, res) => {
             return res.status(400).json({ error: 'User ID is required' });
         }
 
-        const personalExpenses = await Expense.filterById(userId, 'user');
+        const personalExpenses = await Expense.filterById(userId, 'user', req.supabase);
         let sharedExpenses = [];
 
         if (sharedAccountId) {
-            sharedExpenses = await Expense.filterById(sharedAccountId, 'sharedAccount');
+            sharedExpenses = await Expense.filterById(sharedAccountId, 'sharedAccount', req.supabase);
         }
 
         if (!personalExpenses || !sharedExpenses) {
-            return res.status(404).json({ message: 'No expenses found for the sepcified user or shared account' });
+            return res.status(404).json({ message: 'No expenses found for the specified user or shared account' });
         }
 
-        const allExpenses = [...personalExpenses, ...sharedExpenses]
+        const allExpenses = [...personalExpenses, ...sharedExpenses];
 
         if (allExpenses.length === 0) {
-            return res.status(200).json(allExpenses)
+            return res.status(200).json(allExpenses);
         }
 
         // initialize an empty map to automatically handle uniqueness
@@ -60,7 +60,7 @@ const addNewPersonalExpense = async (req, res) => {
     }
 
     try {
-        await Expense.addExpense(newExpense);
+        await Expense.addExpense(newExpense, req.supabase);
         res.status(201).json({ message: 'New personal expense added successfully'})
     } catch(error) {
         res.status(500).json({ error: error.message });
@@ -98,7 +98,7 @@ const addNewSharedExpense = async (req, res) => {
     }
 
     try {
-        await Expense.addExpense(newExpense);
+        await Expense.addExpense(newExpense, req.supabase);
         res.status(201).json({ message: 'New shared expense added successfully'})
     } catch(error) {
         res.status(500).json({ error: error.message });

--- a/src/controllers/profileController.js
+++ b/src/controllers/profileController.js
@@ -3,38 +3,35 @@ const User = require('../models/profileModel');
 // creates a user profile upon sign up
 const createUserProfile = async (req, res) => {
     try {
-        const { user_id, name } = req.body;
+        const { userId, email, name } = req.body;
         
-        const result = await User.createProfile({ user_id, name });
-        const newProfile = result[0];
+        if (!userId || !email || !name) {
+            return res.status(400).json({ error: 'Required fields are missing' });
+        }
 
-        res.status(201).json({ 
-            message: 'User profile created successfully', 
-            profile: {
-                name: newProfile.name,
-            } 
-        })
+        await User.createProfile({ 'user_id': userId, email, name }, req.supabase);
+        res.status(201).json({ message: 'User profile created successfully'});
     } catch(error) {
         res.status(500).json({ error: error.message });
     }
-}
+};
 
 // Find a user profile by user Id
 const findProfileByUserId = async (req, res) => {
     try {
         const { userId } = req.params;
         
-        const result = await User.findByUserId(userId);
+        const result = await User.findByUserId(userId, req.supabase);
 
         if (!result || result.length === 0) {
             return res.status(404).json({ message: 'Profile not found' });
         }
 
         const profile = result[0];
-        res.status(200).json(profile)
+        res.status(200).json(profile);
     } catch(error) {
         res.status(500).json({ error: error.message });
     }
-}
+};
 
 module.exports = { createUserProfile, findProfileByUserId };

--- a/src/controllers/sharedAccountController.js
+++ b/src/controllers/sharedAccountController.js
@@ -41,14 +41,14 @@ const findSharedAccountByUserId = async (req, res) => {
             return res.status(400).json({ message: 'User ID is required' });
         }
         
-        const result = await SharedAccount.findByUserId(userId);
+        const result = await SharedAccount.findByUserId(userId, req.supabase);
 
         if (!result || result.length === 0) {
             return res.status(404).json({ message: 'No shared account found for this user' });
         }
 
         const sharedAccount = result[0];
-        res.status(200).json(sharedAccount)
+        res.status(200).json(sharedAccount);
     } catch(error) {
         res.status(500).json({ error: error.message });
     }

--- a/src/controllers/sharedAccountController.js
+++ b/src/controllers/sharedAccountController.js
@@ -9,7 +9,7 @@ const createSharedAccount = async (req, res) => {
     }
 
     try {
-        await SharedAccount.createAccount({ 'user1_id': userId, 'unique_code': uniqueCode });
+        await SharedAccount.createAccount({ 'user1_id': userId, 'unique_code': uniqueCode }, req.supabase);
         res.status(201).json({ message: 'Shared account created successfully'})
     } catch(error) {
         res.status(500).json({ error: error.message });
@@ -26,7 +26,11 @@ const addUserToSharedAccount = async (req, res) => {
             return res.status(400).json({ error: 'Missing required fields' });
         }
         
-        await SharedAccount.updateAccountByInviteCode(code, { 'user2_id': user2Id, 'updated_at': timestamp });
+        await SharedAccount.updateAccountByInviteCode(
+            code, 
+            { 'user2_id': user2Id, 'updated_at': timestamp },
+            req.supabase
+        );
         res.status(200).json({ message: 'User added to the shared account successfully'})
     } catch (error) {
         res.status(500).json({ error: error.message });

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -1,4 +1,4 @@
-const { supabase } = require('../supabaseClient');
+const { getSupabaseClientWithAuth } = require('../supabaseClient');
 
 const verifyToken = async (req, res, next) => {
   try {
@@ -9,18 +9,18 @@ const verifyToken = async (req, res, next) => {
     }
 
     const token = authHeader.split(' ')[1];
+    const supabase = getSupabaseClientWithAuth(token);
     
-    const { data: { user }, error } = await supabase.auth.getUser(token);
+    const { data: { user }, error } = await supabase.auth.getUser();
 
     if (error || !user) {
       return res.status(401).json({ error: 'Invalid token' });
     }
 
-    // Attach user to request object for use in route handlers
     req.user = user;
+    req.supabase = supabase;
     next();
   } catch (error) {
-    console.error('Token verification error:', error);
     res.status(500).json({ error: 'Internal server error during token verification' });
   }
 };

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -1,0 +1,28 @@
+const { supabase } = require('../supabaseClient');
+
+const verifyToken = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+    
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'No token provided' });
+    }
+
+    const token = authHeader.split(' ')[1];
+    
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+
+    if (error || !user) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+
+    // Attach user to request object for use in route handlers
+    req.user = user;
+    next();
+  } catch (error) {
+    console.error('Token verification error:', error);
+    res.status(500).json({ error: 'Internal server error during token verification' });
+  }
+};
+
+module.exports = { verifyToken }; 

--- a/src/models/expenseModel.js
+++ b/src/models/expenseModel.js
@@ -1,10 +1,7 @@
-const { supabase } = require('../supabaseClient')
-
 const Expense = {
 
     // Filter expenses by user id or shared account id
-    filterById: async (id, idType) => {
-
+    filterById: async (id, idType, supabase) => {
         const columnName = idType === 'user' ? 'user_id' : 'shared_account_id' 
 
         const { data, error } = await supabase
@@ -35,10 +32,11 @@ const Expense = {
         return data;
     },
 
-    addExpense: async (expense) => {
+    addExpense: async (expense, supabase) => {
         const { data, error } = await supabase
             .from('expenses')
             .insert(expense)
+            .select();
 
         if(error) {
             throw new Error(error.message);

--- a/src/models/profileModel.js
+++ b/src/models/profileModel.js
@@ -1,13 +1,9 @@
-const { supabase } = require('../supabaseClient')
-
 const User = {
-
-    // Inserts new user data to Supabase
-    createProfile: async (userData) => {
+    createProfile: async (profileData, supabase) => {
         const { data, error } = await supabase
             .from('profiles')
-            .insert(userData)
-            .select()
+            .insert(profileData)
+            .select();
 
         if(error) {
             throw new Error(error.message);
@@ -16,19 +12,18 @@ const User = {
         return data;
     },
 
-    findByUserId: async (userId) => {
+    findByUserId: async (userId, supabase) => {
         const { data, error } = await supabase
             .from('profiles')
             .select('*')
             .eq('user_id', userId);
 
         if (error) {
-            console.error('Error fetching user profile:', error);
             return null;
         }
 
         return data;
     }
-}
+};
 
 module.exports = User;

--- a/src/models/sharedAccountModel.js
+++ b/src/models/sharedAccountModel.js
@@ -1,5 +1,3 @@
-const { supabase } = require('../supabaseClient')
-
 const SharedAccount = {
 
     createAccount: async (accountData) => {
@@ -27,24 +25,23 @@ const SharedAccount = {
         }
     },
 
-    findByUserId: async (userId) => {
+    findByUserId: async (userId, supabase) => {
         const { data, error } = await supabase
             .from('shared_accounts')
             .select('uuid, user1_id, user2_id, unique_code')
             .or(`user1_id.eq.${userId},user2_id.eq.${userId}`);
 
         if (error) {
-            console.error('Error fetching shared account:', error);
             return null;
         }
 
-        if (data.length > 0) {
+        if (data && data.length > 0) {
             return data.map((sharedAccount) => ({
                 uuid: sharedAccount.uuid,
                 user1Id: sharedAccount.user1_id,
                 user2Id: sharedAccount.user2_id,
                 uniqueCode: sharedAccount.unique_code,
-            }))
+            }));
         }
 
         return data;

--- a/src/models/sharedAccountModel.js
+++ b/src/models/sharedAccountModel.js
@@ -1,6 +1,6 @@
 const SharedAccount = {
 
-    createAccount: async (accountData) => {
+    createAccount: async (accountData, supabase) => {
         const { data, error } = await supabase
             .from('shared_accounts')
             .insert(accountData)
@@ -14,7 +14,7 @@ const SharedAccount = {
         return data;
     },
 
-    updateAccountByInviteCode: async(inviteCode, updatedData) => {
+    updateAccountByInviteCode: async(inviteCode, updatedData, supabase) => {
         const { error } = await supabase
             .from('shared_accounts')
             .update(updatedData)

--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,7 @@ const corsOptions = {
     origin: ['https://wisetogether.onrender.com', 'http://localhost:5173'],
     methods: ['GET', 'POST', 'PATCH', 'DELETE'], 
     allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: false,
+    credentials: true,
   };
   
 app.use(cors(corsOptions));

--- a/src/server.js
+++ b/src/server.js
@@ -3,26 +3,26 @@ const app = express();
 const cors = require('cors');
 const profileRoutes = require('./routes/profileRoutes');
 const sharedAccountRoutes = require('./routes/sharedAccountRoutes');
-const expenseRoutes = require('./routes/expenseRoutes')
+const expenseRoutes = require('./routes/expenseRoutes');
+const { verifyToken } = require('./middleware/authMiddleware');
 
-
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 8080;
 
 app.use(express.json());
 
 const corsOptions = {
     origin: ['https://wisetogether.onrender.com', 'http://localhost:5173'],
     methods: ['GET', 'POST', 'PATCH', 'DELETE'], 
-    allowedHeaders: ['Content-Type'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: false,
   };
   
 app.use(cors(corsOptions));
 
-// API routes
-app.use('/profiles', profileRoutes);
-app.use('/shared-accounts', sharedAccountRoutes);
-app.use('/expenses', expenseRoutes);
+// API routes with auth middleware
+app.use('/profiles', verifyToken, profileRoutes);
+app.use('/shared-accounts', verifyToken, sharedAccountRoutes);
+app.use('/expenses', verifyToken, expenseRoutes);
 
 app.listen(PORT, () => {
 	console.log(`Server running on port ${PORT}`);

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,5 +3,14 @@ const { createClient } = require('@supabase/supabase-js');
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
-module.exports = { supabase };
+const getSupabaseClientWithAuth = (token) => {
+    return createClient(supabaseUrl, supabaseAnonKey, {
+      global: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    });
+};
+
+module.exports = { getSupabaseClientWithAuth };


### PR DESCRIPTION
Resolves #2 

## What changed

Previously, the Supabase client was globally instantiated without request-specific authentication and protected routes did not verify JWT tokens. This PR introduces a new `authMiddleware` that verifies Supabase JWT tokens. It also adds a `getSupabaseClientWithAuth(token)` utility to create an authenticated Supabase client per request. The `sharedAccountController` and `sharedAccountModel` were refactored to accept this authenticated client. Finally, the middleware was applied to protected routes in `server.js`, along with CORS header updates to allow Authorization.

## Testing instructions

1. Make an authenticated request to a protected route (e.g. `/shared-account/:userId`)
2. Confirm that:
  - The token is correctly verified
  - `req.supabase` or the passed client is valid and can retrieve data
  - Invalid or missing tokens are rejected with a 401

You can test this in Postman:
- Add an Authorization header: `Bearer <your_supabase_jwt_token>`

## Screenshots

![image](https://github.com/user-attachments/assets/817a0f78-0aa5-43c3-a595-7671a8ff44c5)
![image](https://github.com/user-attachments/assets/6cb6f900-5faf-4018-9c7f-2563c5819356)
