### PR TITLE
feat: add API endpoint for editing transactions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,10 @@ All notable changes to the WiseTogether server directory are documented here.
 
 ### Added
 - New API endpoint: `PATCH /transactions/:id` for editing transactions [#1](https://github.com/WiseTogether/wisetogether-server/issues/1)
-- Middleware for Supabase token verification [#2](https://github.com/WiseTogether/wisetogether-server/issues/2)
 
 ---
 
+## [2025-06-08]
+
+### Added
+- Middleware for Supabase token verification [#2](https://github.com/WiseTogether/wisetogether-server/issues/2) ([#4](https://github.com/WiseTogether/wisetogether-server/pull/4))

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -46,3 +46,34 @@ To test the implementation:
 
 ---
 
+## Feat: Implement Edit Transaction API Endpoint
+**Issue:** [#1](https://github.com/WiseTogether/wisetogether-server/issues/1)
+
+### Problem
+No logic for editing expenses. Users need the ability to modify existing expense details.
+
+### Implementation
+1. Added `updateExpense` function to `expenseModel.js`:
+   - Updates expense by UUID
+   - Returns formatted expense data
+   - Handles error cases appropriately
+
+2. Added `updateExpense` controller to `expenseController.js`:
+   - Supports partial updates of expense fields
+   - Validates required parameters
+   - Automatically recalculates split amounts when amount or split type changes
+   - Returns updated expense data
+
+3. Updated `expenseRoutes.js` to:
+   - Add PATCH endpoint for expense updates
+   - Route: `/expenses/:expenseId`
+
+### Testing
+To test the implementation:
+1. Send PATCH request to `/expenses/:expenseId`
+2. Include any combination of updatable fields in request body
+3. For split expenses, amount or split type changes will trigger automatic recalculation
+4. Verify response contains updated expense data
+
+---
+

--- a/src/models/expenseModel.js
+++ b/src/models/expenseModel.js
@@ -43,6 +43,35 @@ const Expense = {
         }
 
         return data;
+    },
+
+    updateExpense: async (expenseId, updatedData, supabase) => {
+        const { data, error } = await supabase
+            .from('expenses')
+            .update(updatedData)
+            .eq('uuid', expenseId)
+            .select();
+
+        if(error) {
+            throw new Error(error.message);
+        }
+
+        if (data && data.length > 0) {
+            const expense = data[0];
+            return {
+                id: expense.uuid,
+                sharedAccountId: expense.shared_account_id,
+                userId: expense.user_id,
+                date: expense.date,
+                amount: expense.amount,
+                category: expense.category,
+                description: expense.description,
+                splitType: expense.split_type,
+                splitDetails: expense.split_details,
+            };
+        }
+
+        return null;
     }
     
 }

--- a/src/routes/expenseRoutes.js
+++ b/src/routes/expenseRoutes.js
@@ -1,11 +1,16 @@
 const express = require('express');
 const router = express.Router();
-const { fetchAllExpensesById, addNewPersonalExpense, addNewSharedExpense } = require('../controllers/expenseController')
+const { 
+    fetchAllExpensesById, 
+    addNewPersonalExpense, 
+    addNewSharedExpense,
+    updateExpense 
+} = require('../controllers/expenseController');
 
 router.get('/', fetchAllExpensesById);
 router.post('/personal', addNewPersonalExpense);
 router.post('/shared', addNewSharedExpense);
-// router.patch('/:expenseId', );
+router.patch('/:expenseId', updateExpense);
 // router.delete('/:expenseId', );
 
 module.exports = router;


### PR DESCRIPTION
Resolves #1 

## 🔧 What changed

- Added updateExpense to `expenseModel.js` for updating expense records by UUID, with error handling and data formatting.
- Created a new controller in `expenseController.js` to handle partial updates, validate input, and recalculate split amounts when necessary.
- Registered a new route in `expenseRoutes.js` to expose a `PATCH /expenses/:expenseId` endpoint for editing expenses.

## 🧪 Testing instructions

- Send a `PATCH` request to `/expenses/:expenseId` with fields to update in the body.
- Updating `amount` or `split_type` will automatically trigger recalculation logic.
- Response will include the updated expense object.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/30f5f2a3-0280-4de0-a8f2-4d9d765b45fb)
![image](https://github.com/user-attachments/assets/68ae0d4a-4f3e-47aa-8760-5e03e220f546)
