### PR TITLE
refactor: return the created expense data in POST/expenses response

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -77,3 +77,38 @@ To test the implementation:
 
 ---
 
+<<<<<<< HEAD
+=======
+## Feat: Refactor Expense Creation Response
+**Issue:** [#6](https://github.com/WiseTogether/wisetogether-server/issues/6)
+
+### Problem
+Expense creation endpoints only return success messages without the created expense data, requiring additional API calls to get the new expense details.
+
+### Implementation
+1. Updated `expenseModel.js`:
+   - Modified `addExpense` function to return formatted expense data
+   - Added consistent data formatting with other expense endpoints
+   - Maintained error handling
+
+2. Updated `expenseController.js`:
+   - Modified `addNewPersonalExpense` to return created expense
+   - Modified `addNewSharedExpense` to return created expense
+   - Maintained existing validation and error handling
+
+### API Endpoints
+- POST `/expenses/personal`
+  - Returns: Created expense object with all fields
+- POST `/expenses/shared`
+  - Returns: Created expense object with all fields including split details
+
+### Testing
+To test the implementation:
+1. Create a new personal or shared expense
+2. Verify response contains complete expense object
+3. Verify all fields are correctly formatted
+4. For shared expenses, verify split details are included
+
+---
+
+>>>>>>> d13fd43 (refactor: return the created expense data in POST/expenses response)

--- a/src/controllers/expenseController.js
+++ b/src/controllers/expenseController.js
@@ -46,36 +46,41 @@ const fetchAllExpensesById = async (req, res) => {
 }
 
 const addNewPersonalExpense = async (req, res) => {
-
     const { userId, date, amount, category, description } = req.body;
 
     if (!userId || !date || !amount || !category) {
         return res.status(400).json({ error: 'Required fields are missing' });
     }
 
-    let newExpense = { 'user_id':userId, date, amount, category };
+    let newExpense = { 'user_id': userId, date, amount, category };
 
     if (description) {
         newExpense.description = description;
     }
 
     try {
-        await Expense.addExpense(newExpense, req.supabase);
-        res.status(201).json({ message: 'New personal expense added successfully'})
+        const createdExpense = await Expense.addExpense(newExpense, req.supabase);
+        res.status(201).json(createdExpense);
     } catch(error) {
         res.status(500).json({ error: error.message });
     }
-}
+};
 
 const addNewSharedExpense = async (req, res) => {
-
     const { sharedAccountId, userId, date, amount, category, description, splitType, splitDetails } = req.body;
 
     if (!sharedAccountId || !userId || !date || !amount || !category || !splitType) {
         return res.status(400).json({ error: 'Required fields are missing' });
     }
 
-    let newExpense = { 'user_id':userId, 'shared_account_id':sharedAccountId, date, amount, category, 'split_type':splitType };
+    let newExpense = { 
+        'user_id': userId, 
+        'shared_account_id': sharedAccountId, 
+        date, 
+        amount, 
+        category, 
+        'split_type': splitType 
+    };
     
     if (description) {
         newExpense.description = description;
@@ -90,7 +95,6 @@ const addNewSharedExpense = async (req, res) => {
 
     if (splitType === 'percentage' && splitDetails) {
         const { user1, user2 } = splitDetails;
-
         newExpense.split_details = {
             user1_amount: Math.round((user1 / 100) * amount),
             user2_amount: Math.round((user2 / 100) * amount)
@@ -98,12 +102,12 @@ const addNewSharedExpense = async (req, res) => {
     }
 
     try {
-        await Expense.addExpense(newExpense, req.supabase);
-        res.status(201).json({ message: 'New shared expense added successfully'})
+        const createdExpense = await Expense.addExpense(newExpense, req.supabase);
+        res.status(201).json(createdExpense);
     } catch(error) {
         res.status(500).json({ error: error.message });
     }
-}
+};
 
 const updateExpense = async (req, res) => {
     try {

--- a/src/models/expenseModel.js
+++ b/src/models/expenseModel.js
@@ -42,7 +42,22 @@ const Expense = {
             throw new Error(error.message);
         }
 
-        return data;
+        if (data && data.length > 0) {
+            const newExpense = data[0];
+            return {
+                id: newExpense.uuid,
+                sharedAccountId: newExpense.shared_account_id,
+                userId: newExpense.user_id,
+                date: newExpense.date,
+                amount: newExpense.amount,
+                category: newExpense.category,
+                description: newExpense.description,
+                splitType: newExpense.split_type,
+                splitDetails: newExpense.split_details,
+            };
+        }
+
+        return null;
     },
 
     updateExpense: async (expenseId, updatedData, supabase) => {


### PR DESCRIPTION
Resolves #6 

## What Changed

Updated the `POST /expenses` API endpoint to return the full created expense object instead of a generic success message. This improves the client experience by allowing immediate use of the returned data without requiring a follow-up API call.
- modified `expenseController.js` and `expenseModel.js` to return the inserted expense record

## Testing Instructions

1. Send a POST request to `/expenses` with a valid expense payload.
2. Verify that the response includes the newly created expense data.

## Screenshots

### Before
![Image](https://github.com/user-attachments/assets/fe153a2b-ba5f-4eef-8736-ff367ab5b447)

### After
![Image](https://github.com/user-attachments/assets/72b3aa6b-a9a2-4b38-856e-033e683621fa)
